### PR TITLE
fix: modal button overlap + faster file open; chore: repo URLs, changelog, version-bump script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Unsaved-changes dialog buttons no longer overlap (added spacing to the action row).
+- Files open from the Explorer noticeably faster — the native-menu rebuild is now deferred until after the document renders instead of blocking it.
+
 ## [2.1.4]
 
 ### Fixed
+- **Find in Files** now opens reliably from the Edit menu, including when the sidebar is collapsed (previously did nothing).
+- **Command Palette** is now reachable from the View menu, and `Ctrl`/`Cmd`+`P` opens it instead of triggering the OS print dialog.
+- **Right-click Copy/Paste** in the editor now works across platforms (routed through the Tauri clipboard plugin).
+- **File Explorer "Refresh"** preserves expanded folders instead of collapsing the tree.
 - Fixed a blank window on launch caused by a mismatched `react` / `react-dom` version in the previous 2.1.4 build; both are now pinned to the same release.
+
+### Changed
+- Word Wrap setting under Appearance no longer wraps onto two lines.
+- Regenerated a multi-resolution Windows icon (`icon.ico`) so the taskbar icon is no longer blurry.
+- Updated dependencies (React 19.2.7, marked 18, Tauri 2.11.3) and consolidated CI into a single workflow with grouped Dependabot updates; added a CI guard that fails the build if `react` and `react-dom` versions differ.
 
 ### Security
 - Added least-privilege `permissions:` blocks to all CI/release workflows.
 - Session identifiers now use `crypto.randomUUID()` instead of `Math.random()`.
 - Updated the `rand` crate to 0.8.6 (addresses a RUSTSEC advisory).
-
-### Changed
-- Updated dependencies (React 19.2.7, marked 18, Tauri 2.11.3) and consolidated CI into a single workflow with grouped Dependabot updates.
 
 ## [2.1.3]
 
@@ -49,6 +59,6 @@ Initial public release baseline. Highlights:
 - Light/dark themes that follow the OS theme on first launch
 - Update notifications with one-click download from the website
 
-[Unreleased]: https://github.com/zitrino-products/zitext-community/compare/v2.1.3...HEAD
-[2.1.3]: https://github.com/zitrino-products/zitext-community/releases/tag/v2.1.3
-[2.1.2]: https://github.com/zitrino-products/zitext-community/releases/tag/v2.1.2
+[Unreleased]: https://github.com/zitrino-oss/zitext-editor/compare/v2.1.3...HEAD
+[2.1.3]: https://github.com/zitrino-oss/zitext-editor/releases/tag/v2.1.3
+[2.1.2]: https://github.com/zitrino-oss/zitext-editor/releases/tag/v2.1.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md)
 ## Getting started
 
 ```bash
-git clone https://github.com/zitrino-products/zitext-community.git
+git clone https://github.com/zitrino-oss/zitext-editor.git
 cd zitext-community
 npm install
 npm run tauri dev

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ React, TypeScript, and the Monaco Editor. Simple, fast, and feature-rich.
 ## Getting started
 
 ```bash
-git clone https://github.com/zitrino-products/zitext-community.git
+git clone https://github.com/zitrino-oss/zitext-editor.git
 cd zitext-community
 npm install
 npm run tauri dev

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "homepage": "https://zitext.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zitrino-products/zitext-community.git"
+    "url": "https://github.com/zitrino-oss/zitext-editor.git"
   },
   "bugs": {
-    "url": "https://github.com/zitrino-products/zitext-community/issues"
+    "url": "https://github.com/zitrino-oss/zitext-editor/issues"
   },
   "type": "module",
   "overrides": {
@@ -22,7 +22,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "bump": "node scripts/bump-version.mjs"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -64,7 +64,9 @@ const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (local node, 
 edit('CHANGELOG.md', (s) => {
     let out = s;
     // 1) Insert a dated section under [Unreleased] (skip if it already exists).
-    if (!new RegExp(`^## \\[${version.replace(/\./g, '\\.')}\\]`, 'm').test(out)) {
+    //    Plain string match (not a regex built from input) — `version` is
+    //    validated semver, and there's no need to construct a RegExp from it.
+    if (!out.includes(`## [${version}]`)) {
         out = out.replace(
             /## \[Unreleased\]\s*\n/,
             `## [Unreleased]\n\n## [${version}] - ${today}\n\n### Added\n\n### Changed\n\n### Fixed\n\n`
@@ -75,7 +77,7 @@ edit('CHANGELOG.md', (s) => {
         /\[Unreleased\]:\s*\S+/,
         `[Unreleased]: ${REPO}/compare/v${version}...HEAD`
     );
-    if (!new RegExp(`^\\[${version.replace(/\./g, '\\.')}\\]:`, 'm').test(out)) {
+    if (!out.includes(`[${version}]:`)) {
         out = out.replace(
             /(\[Unreleased\]:[^\n]*\n)/,
             `$1[${version}]: ${REPO}/releases/tag/v${version}\n`

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Single-command version bump for ZITEXT Editor.
+ *
+ *   node scripts/bump-version.mjs <version>      # e.g. 2.1.5
+ *   npm run bump 2.1.5
+ *
+ * Updates every place the version lives so they never drift again:
+ *   - src-tauri/tauri.conf.json   (the authoritative app version)
+ *   - package.json
+ *   - src-tauri/Cargo.toml        ([package] version)
+ *   - src-tauri/Cargo.lock        (the zitext-editor crate entry)
+ *   - CHANGELOG.md                (adds a dated [x.y.z] section + footer links)
+ *
+ * It does NOT commit, tag, or push — review the diff, then:
+ *   git checkout -b release/vX.Y.Z && git commit -am "release: X.Y.Z" && open a PR
+ * After the PR merges, run the "Release Build" workflow with the same version.
+ * The website (downloads + docs) reads the version from the published
+ * release manifest, so it updates automatically — no website edit needed.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO = 'https://github.com/zitrino-oss/zitext-editor';
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+    console.error('Usage: node scripts/bump-version.mjs <semver>   (e.g. 2.1.5)');
+    process.exit(1);
+}
+
+const log = (f, msg) => console.log(`  ✓ ${f.padEnd(28)} ${msg}`);
+
+function edit(rel, fn) {
+    const path = join(ROOT, rel);
+    const before = readFileSync(path, 'utf8');
+    const after = fn(before);
+    if (after === before) {
+        console.warn(`  ! ${rel.padEnd(28)} no change (pattern not found?)`);
+        return;
+    }
+    writeFileSync(path, after);
+}
+
+// --- config files -----------------------------------------------------------
+edit('src-tauri/tauri.conf.json', (s) => s.replace(/("version":\s*")[^"]+(")/, `$1${version}$2`));
+log('src-tauri/tauri.conf.json', `version -> ${version}`);
+
+edit('package.json', (s) => s.replace(/("version":\s*")[^"]+(")/, `$1${version}$2`));
+log('package.json', `version -> ${version}`);
+
+edit('src-tauri/Cargo.toml', (s) => s.replace(/^(version\s*=\s*")[^"]+(")/m, `$1${version}$2`));
+log('src-tauri/Cargo.toml', `version -> ${version}`);
+
+edit('src-tauri/Cargo.lock', (s) =>
+    s.replace(/(name = "zitext-editor"\nversion = ")[^"]+(")/, `$1${version}$2`));
+log('src-tauri/Cargo.lock', `zitext-editor -> ${version}`);
+
+// --- CHANGELOG.md ------------------------------------------------------------
+const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (local node, allowed)
+edit('CHANGELOG.md', (s) => {
+    let out = s;
+    // 1) Insert a dated section under [Unreleased] (skip if it already exists).
+    if (!new RegExp(`^## \\[${version.replace(/\./g, '\\.')}\\]`, 'm').test(out)) {
+        out = out.replace(
+            /## \[Unreleased\]\s*\n/,
+            `## [Unreleased]\n\n## [${version}] - ${today}\n\n### Added\n\n### Changed\n\n### Fixed\n\n`
+        );
+    }
+    // 2) Footer links: point [Unreleased] at the new tag and add a tag link.
+    out = out.replace(
+        /\[Unreleased\]:\s*\S+/,
+        `[Unreleased]: ${REPO}/compare/v${version}...HEAD`
+    );
+    if (!new RegExp(`^\\[${version.replace(/\./g, '\\.')}\\]:`, 'm').test(out)) {
+        out = out.replace(
+            /(\[Unreleased\]:[^\n]*\n)/,
+            `$1[${version}]: ${REPO}/releases/tag/v${version}\n`
+        );
+    }
+    return out;
+});
+log('CHANGELOG.md', `added [${version}] - ${today} + footer links`);
+
+console.log(`\nBumped to ${version}. Review the diff, fill in the CHANGELOG bullets,`);
+console.log('commit on a branch, open a PR, then run the Release Build workflow with the same version.');

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.1.4"
 description = "A fast, lightweight, cross-platform text and code editor built with Tauri and Monaco."
 authors = ["Zitrino"]
 license = "Apache-2.0"
-repository = "https://github.com/zitrino-products/zitext-community"
+repository = "https://github.com/zitrino-oss/zitext-editor"
 homepage = "https://zitext.com"
 edition = "2021"
 

--- a/src/state/useFileManager.ts
+++ b/src/state/useFileManager.ts
@@ -127,22 +127,31 @@ export function useFileManager(
             endTimer('file-open');
             addTab(newTab);
             added = true;
-            await addRecentFile(path);
 
-            // Trigger React state update for recent files if callback provided
-            if (onRecentFilesChanged) {
-                await onRecentFilesChanged();
-            }
-
-            // Only rebuild menu if not skipping (to avoid race conditions with menu clicks)
-            if (!skipMenuRebuild) {
-                await rebuildNativeMenu();
-            }
-
-            // Start watching file for external changes
+            // Start watching file for external changes (cheap, no UI cost).
             fileWatcher.watch(path, () => {
                 markExternallyModified(newTab.id);
             });
+
+            // Defer recent-files persistence and the native-menu rebuild until
+            // after the document paints. Rebuilding the macOS native menu runs on
+            // the main thread (shared with the WebView), so doing it inline holds
+            // the just-opened file off screen for a noticeable beat — especially
+            // for files opened from the Explorer (which don't skip the rebuild).
+            // A macrotask lets the editor render first, then the menu updates.
+            setTimeout(async () => {
+                try {
+                    await addRecentFile(path);
+                    if (onRecentFilesChanged) {
+                        await onRecentFilesChanged();
+                    }
+                    if (!skipMenuRebuild) {
+                        await rebuildNativeMenu();
+                    }
+                } catch (err) {
+                    console.error('[openFile] deferred recent-files/menu update failed:', err);
+                }
+            }, 0);
 
             return newTab.id;
         } catch (error) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3484,6 +3484,8 @@ body {
 .modal-actions {
   padding: 0 36px 28px;
   display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
   justify-content: center;
 }
 .modal-btn {


### PR DESCRIPTION
Combined follow-up PR (app fixes + repo cleanup/tooling). Not part of the 2.1.4 build — these ride the next release.

## 🐛 App fixes
- **Unsaved-changes / quit dialog buttons no longer overlap** — `.modal-actions` had `display:flex; justify-content:center` with no `gap`; added `gap:12px` + `flex-wrap`.
- **Files open from the Explorer noticeably faster** — `openFile` was `await`ing a full native-menu rebuild on every Explorer open. On macOS the native menu + WebView share the main thread, so the rebuild blocked the just-opened document from painting. Recent-files persistence + menu rebuild are now deferred to a macrotask; the editor paints first. *(Verified live in `tauri dev`.)*

## 🔧 Repo cleanup / tooling
- Repointed all repository URLs `zitrino-products/zitext-community` → `zitrino-oss/zitext-editor` (`package.json`, `README.md`, `CONTRIBUTING.md`, `Cargo.toml`, `CHANGELOG.md` footer).
- Expanded the 2.1.4 changelog with the full fix list; added an `[Unreleased]` section for the two app fixes.
- **`scripts/bump-version.mjs`** (+ `npm run bump <version>`): one command updates the version across `tauri.conf.json`, `package.json`, `Cargo.toml`, `Cargo.lock` and scaffolds a dated CHANGELOG section + footer links — so versions never drift (the cause of the blank-2.1.4 confusion). Tested in isolation.

Validated locally: `tsc` clean, eslint 0 errors, file-open fix verified by running the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)