### PR TITLE
chore(deps): temporarily ignore vite 8.1.5 (rolldown ?worker regression)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,13 @@ updates:
       # load. Remove this once typescript-eslint ships stable TS 7 support.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # TEMPORARY: vite 8.1.5 bundles rolldown 1.1.5, which regressed
+      # resolution of the `monaco-editor/...editor.worker?worker` import and
+      # breaks `vite build` (PR #58). Pin out just the bad version so the
+      # grouped bump can still land the other updates; a fixed release
+      # (8.1.6+) will flow through normally. Remove once confirmed fixed.
+      - dependency-name: "vite"
+        versions: ["8.1.5"]
 
   # Rust backend dependencies (Cargo)
   - package-ecosystem: "cargo"


### PR DESCRIPTION
## Why

The grouped npm bump #58 fails CI (both **Lint/type-check/build** and the **Rust** job, which runs `npm run build`). Root cause:

```
[vite]: Rolldown failed to resolve import
"monaco-editor/esm/vs/editor/editor.worker?worker" from src/monaco-config.ts
```

- Verified **monaco 0.56 is not the cause** — it still ships `esm/vs/editor/editor.worker.js` at the same path.
- The break is a **regression in vite 8.1.5 / rolldown 1.1.5** handling of the `?worker` query import.

Unlike the TS 7 / ESLint 10 holds, this is a *transient upstream regression*, not a permanent ecosystem gap.

## Change

Pin out **only** `vite@8.1.5` (via `versions: ["8.1.5"]`), not all vite updates. Dependabot then re-forms the grouped bump **without** vite, so the other 5 updates (marked, monaco-editor, @tauri-apps/plugin-dialog, @typescript-eslint/*) can land green. A fixed release (8.1.6+) will flow through normally.

**Remove this entry** once the regression is confirmed fixed upstream.

Related: closing #58 separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)