### PR TITLE
fix(bench): use std::hint::black_box (criterion 0.8 deprecation)

### DIFF
--- a/src-tauri/benches/file_operations.rs
+++ b/src-tauri/benches/file_operations.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs;
+use std::hint::black_box;
 use std::io::Write;
 use tempfile::TempDir;
 use zitext_editor_lib::benchmark_support;


### PR DESCRIPTION
## Problem
`main`'s Rust CI job (`Rust format, check, test & Clippy`) is currently **failing**, and it drags down every open PR's Rust check (#73, #74):

```
error: use of deprecated function `criterion::black_box`: use `std::hint::black_box()` instead
 --> benches/file_operations.rs:1
```

A `criterion` **0.8** major bump landed on `main` (via the cargo-major auto-flow). criterion 0.8 deprecated `criterion::black_box`; clippy runs with `-D warnings`, so the deprecation is a hard error.

It slipped onto `main` because the Rust job is **not a required status check** — only `Lint, type-check & build` is — so the frontend-green PR merged while breaking Rust. (Making Rust required is being handled separately.)

## Fix
Import `black_box` from `std::hint` instead of `criterion`. The 9 call sites are unchanged. Import order stays rustfmt-clean (`fs` < `hint` < `io`).

Restores `main` (and #73/#74's Rust check) to green.