### PR TITLE
release: bump version to 2.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zitext-editor",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zitext-editor",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zitext-editor",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A fast, lightweight, cross-platform text and code editor built with Tauri and Monaco.",
   "author": "Zitrino",
   "license": "Apache-2.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6208,7 +6208,7 @@ dependencies = [
 
 [[package]]
 name = "zitext-editor"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "criterion",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zitext-editor"
-version = "2.1.4"
+version = "2.1.5"
 description = "A fast, lightweight, cross-platform text and code editor built with Tauri and Monaco."
 authors = ["Zitrino"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "ZITEXT Editor",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "identifier": "com.zitrino.zitext",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bumps the project version from 2.1.4 to 2.1.5 across all manifests so the `v2.1.5` release tag passes the version-consistency gate (`scripts/verify-release-version.mjs`).

Files updated:
- `package.json`
- `package-lock.json` (root `version` + `packages[""].version`)
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (`zitext-editor` package entry)

The `## [2.1.5]` CHANGELOG section already landed in #76. After this merges to `main`, pushing the `v2.1.5` tag will trigger the Release Build workflow.

Verified locally: `node scripts/verify-release-version.mjs 2.1.5` → valid and consistent.